### PR TITLE
Skip validation of request body when content type is not application/json

### DIFF
--- a/lib/rack/json_schema/request_validation.rb
+++ b/lib/rack/json_schema/request_validation.rb
@@ -38,9 +38,9 @@ module Rack
             raise LinkNotFound
           when has_body? && !has_valid_content_type?
             raise InvalidContentType
-          when has_body? && !has_valid_json?
+          when content_type_json? && has_body? && !has_valid_json?
             raise InvalidJson
-          when has_schema? && !has_valid_parameter?
+          when content_type_json? && has_schema? && !has_valid_parameter?
             raise InvalidParameter, "Invalid request.\n#{schema_validation_error_message}"
           end
         end
@@ -72,6 +72,10 @@ module Rack
         # @return [true, false] True if no or matched content type given
         def has_valid_content_type?
           mime_type.nil? || Rack::Mime.match?(link.enc_type, mime_type)
+        end
+
+        def content_type_json?
+          Rack::Mime.match?(link.enc_type, "application/json")
         end
 
         # @return [Array] A result of schema validation for the current action

--- a/spec/fixtures/schema.json
+++ b/spec/fixtures/schema.json
@@ -28,6 +28,12 @@
           "type": [
             "string"
           ]
+        },
+        "file": {
+          "description": "an attachment of app",
+          "example": "",
+          "readOnly": false,
+          "type": "string"
         }
       },
       "links": [
@@ -85,6 +91,24 @@
             ]
           },
           "title": "Update"
+        },
+        {
+          "description": "Upload an attachment file for an app",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fid)}/files",
+          "method": "POST",
+          "rel": "create",
+          "encType": "multipart/form-data",
+          "schema": {
+            "properties": {
+              "file": {
+                "$ref": "#/definitions/app/definitions/file"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
         }
       ],
       "properties": {

--- a/spec/rack/spec_spec.rb
+++ b/spec/rack/spec_spec.rb
@@ -146,6 +146,27 @@ describe Rack::JsonSchema do
       end
     end
 
+    context "with non-json content type with non-json request body", :with_valid_post_request do
+
+      let(:path) do
+        "/apps/#{app_id}/files"
+      end
+
+      let(:app_id) do
+        1
+      end
+
+      let(:params) do
+        { file: Rack::Test::UploadedFile.new(schema_path, 'text/x-yaml') }
+      end
+
+      before do
+        env["CONTENT_TYPE"] = "multipart/form-data"
+      end
+
+      it { should == 200 }
+    end
+
     context "with malformed JSON request body", :with_valid_post_request do
       let(:params) do
         "malformed"


### PR DESCRIPTION
According to [draft-04 of JSON Hyper-Schema](http://json-schema.org/latest/json-schema-hypermedia.html#anchor37), the server should accept non-json request. 

In this PR, I suggest to skip the validation of json format when `Content-Type` of the client is not `application/json`. 

Also, when the request body is not json, the schema validation will be skipped, though It is desirable to validate paramters on other standard media types including `text/plain`, `multipart/form-data` and `application/x-www-form-urlencoded`.
