### PR TITLE
Skip response validation when status is 3xx

### DIFF
--- a/lib/rack/json_schema/response_validation.rb
+++ b/lib/rack/json_schema/response_validation.rb
@@ -31,7 +31,7 @@ module Rack
         # Raises an error if any error detected, skipping validation for non-defined link
         # @raise [Rack::JsonSchema::ResponseValidation::InvalidResponse]
         def call
-          if !has_error_status? && has_link_for_current_action? && has_link_of_media_type_json?
+          if !has_redirection_or_error_status? && has_link_for_current_action? && has_link_of_media_type_json?
             case
             when !has_json_content_type?
               raise InvalidResponseContentType
@@ -93,10 +93,10 @@ module Rack
           @response[0]
         end
 
-        # Skips validation if status code is equal to or larger than 400
-        # @return [Fixnum]
-        def has_error_status?
-          response_status >= 400
+        # Skips validation if status code is equal to or larger than 300
+        # @return [true, false]
+        def has_redirection_or_error_status?
+          response_status >= 300
         end
 
         # @return [String, nil] Response MIME Type specified in Content-Type header field


### PR DESCRIPTION
### Changes

Skip json validation when the server response is 3xx, since its response body can be something other than JSON.
