### PR TITLE
Fix frozen string literal warning in ResponseValidation#body

### DIFF
--- a/lib/rack/json_schema/response_validation.rb
+++ b/lib/rack/json_schema/response_validation.rb
@@ -88,7 +88,7 @@ module Rack
 
         # @return [String] Response body
         def body
-          result = ""
+          result = String.new
           @response[2].each {|str| result << str }
           result
         end


### PR DESCRIPTION
## Background

- Ruby 3.4 emits a deprecation warning when a mutable string literal (e.g. `""`) is mutated, and Ruby 4.0 will raise `FrozenError`.
- `ResponseValidation::Validator#body` creates an empty string with `""` and appends to it with `<<`, which triggers this warning:


## Fix

- Replaced `""` with `String.new` in `ResponseValidation::Validator#body` to ensure the string is always mutable, avoiding the deprecation warning on Ruby 3.4+ and the `FrozenError` on Ruby 4.0+.
