### PR TITLE
Add Ruby 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         ruby:
           - '3.3'
+          - '3.4'
+          - '4.0'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     rack (3.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
-    rake (13.1.0)
+    rake (13.4.2)
     redcarpet (3.6.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -85,7 +85,7 @@ DEPENDENCIES
   pry
   rack-json_schema!
   rack-test
-  rake
+  rake (>= 13.2.0)
   rspec (>= 2.14.1)
   rspec-console
   rspec-json_matcher

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,7 @@ PATH
   remote: .
   specs:
     rack-json_schema (1.5.5)
-      erubis
-      jdoc (>= 0.4.4)
+      jdoc (>= 0.5.0)
       json_schema (~> 0.2)
       rack
 
@@ -30,12 +29,12 @@ GEM
     diff-lcs (1.5.0)
     drb (2.2.0)
       ruby2_keywords
-    erubis (2.7.0)
+    erubi (1.13.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jdoc (0.4.4)
+    jdoc (0.5.0)
       activesupport
-      erubis
+      erubi
       json_schema
       rack
       redcarpet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,8 +42,11 @@ GEM
     json (2.19.5)
     json_schema (0.21.0)
     method_source (1.0.0)
-    minitest (5.21.1)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     mutex_m (0.2.0)
+    prism (1.9.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -82,6 +85,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.5)
+  minitest (>= 6.0)
   pry
   rack-json_schema!
   rack-test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rack-json_schema (1.5.5)
       jdoc (>= 0.5.0)
+      json (>= 2.7.2)
       json_schema (~> 0.2)
       rack
 
@@ -38,7 +39,7 @@ GEM
       json_schema
       rack
       redcarpet
-    json (2.7.1)
+    json (2.19.5)
     json_schema (0.21.0)
     method_source (1.0.0)
     minitest (5.21.1)

--- a/lib/rack/json_schema.rb
+++ b/lib/rack/json_schema.rb
@@ -1,4 +1,3 @@
-require "erubis"
 require "jdoc"
 require "json"
 require "json_schema"

--- a/rack-json_schema.gemspec
+++ b/rack-json_schema.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json_schema", "~> 0.2"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", ">= 1.5"
+  spec.add_development_dependency "minitest", ">= 6.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake", ">= 13.2.0"

--- a/rack-json_schema.gemspec
+++ b/rack-json_schema.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jdoc", ">= 0.5.0"
+  spec.add_dependency "json", ">= 2.7.2"
   spec.add_dependency "json_schema", "~> 0.2"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", ">= 1.5"

--- a/rack-json_schema.gemspec
+++ b/rack-json_schema.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "erubis"
-  spec.add_dependency "jdoc", ">= 0.4.4"
+  spec.add_dependency "jdoc", ">= 0.5.0"
   spec.add_dependency "json_schema", "~> 0.2"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", ">= 1.5"

--- a/rack-json_schema.gemspec
+++ b/rack-json_schema.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rack-test"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", ">= 13.2.0"
   spec.add_development_dependency "rspec", ">= 2.14.1"
   spec.add_development_dependency "rspec-console"
   spec.add_development_dependency "rspec-json_matcher"


### PR DESCRIPTION
## What
- Support Ruby 4.0

## How
- Replace `erubis` dependency with `jdoc >= 0.5.0`
  - jdoc 0.5.0 replaces erubis with erubi internally
- Add `json >= 2.7.2` as runtime dependency
  - v2.7.2 makes `ostruct` optional, avoiding `LoadError` on Ruby 4.0
- Bump minimum `rake` version to `>= 13.2.0`
- Bump `minitest` to 6.x in Gemfile.lock
- Add Ruby 3.4 and 4.0 to CI test matrix

## Why
- `erubis` is unmaintained and incompatible with Ruby 4.0
- `ostruct` was removed from default gems in Ruby 4.0
  - `json < 2.7.2` unconditionally requires it
  - `rake < 13.2.0` depends on it
- `minitest < 6.0` requires ruby < 4.0